### PR TITLE
Mejoras navegacion

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/easypick/easypick/BaseActivity.kt
+++ b/app/src/main/java/com/easypick/easypick/BaseActivity.kt
@@ -1,11 +1,8 @@
 package com.easypick.easypick
 
 import android.app.ProgressDialog
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
-import android.view.View
-import android.view.inputmethod.InputMethodManager
 
 open class BaseActivity : AppCompatActivity() {
 
@@ -24,11 +21,6 @@ open class BaseActivity : AppCompatActivity() {
         if (progressDialog.isShowing) {
             progressDialog.dismiss()
         }
-    }
-
-    fun hideKeyboard(view: View) {
-        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
 
     public override fun onStop() {

--- a/app/src/main/java/com/easypick/easypick/Principal.kt
+++ b/app/src/main/java/com/easypick/easypick/Principal.kt
@@ -2,6 +2,8 @@ package com.easypick.easypick
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.view.View
 import androidx.fragment.app.Fragment
 import com.easypick.easypick.API.DatabaseAPI
 import com.easypick.easypick.firebase.FirebaseToken
@@ -13,6 +15,7 @@ import com.easypick.easypick.model.Order
 import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.DocumentSnapshot
 import com.easypick.easypick.fragments.*
+import kotlinx.android.synthetic.main.activity_principal.*
 
 
 class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
@@ -56,9 +59,17 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
         val extras: Bundle? = intent?.extras
         if (extras != null){
             if (extras.containsKey("fragment") and extras.containsKey("ordenId")) {
+                Handler().post {
+                    frag_container_principal.visibility = View.GONE
+                    loadingFragment.visibility = View.VISIBLE
+                }
                 val getOrder: Task<DocumentSnapshot> = DatabaseAPI().getOrder(extras["ordenId"] as String)
                 getOrder.addOnSuccessListener { documentSnapshot ->
                     val order = documentSnapshot.toObject(Order::class.java)
+                    Handler().post {
+                        loadingFragment.visibility = View.GONE
+                        frag_container_principal.visibility = View.VISIBLE
+                    }
                     order?.let { ResumenOrdenFragment.newInstance(it) }?.let { showFragment(it) }
                 }
             }

--- a/app/src/main/java/com/easypick/easypick/Principal.kt
+++ b/app/src/main/java/com/easypick/easypick/Principal.kt
@@ -65,5 +65,15 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
         }
     }
 
+    override fun onBackPressed() {
+        if (supportFragmentManager.backStackEntryCount == 1){
+            finish()
+        }
+        else{
+            super.onBackPressed()
+        }
+
+    }
+
 }
 

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentMenu.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentMenu.kt
@@ -59,12 +59,12 @@ class FragmentMenu : Fragment() {
             }
 
             override fun onTabReselected(tab: TabLayout.Tab?) {
-                when(tab?.position!!) {
-                    0 -> { listener?.showFragment(FragmentHome()) }
-                    1 -> { listener?.showFragment(FragmentLocal()) }
-                    3 -> { listener?.showFragment(ForceAuthFragment()) }
-                    4 -> { listener?.showFragment(ProfileFragment())}
-                }
+//                when(tab?.position!!) {
+//                    0 -> { listener?.showFragment(FragmentHome()) }
+//                    1 -> { listener?.showFragment(FragmentLocal()) }
+//                    3 -> { listener?.showFragment(ForceAuthFragment()) }
+//                    4 -> { listener?.showFragment(ProfileFragment())}
+//                }
             }
         })
     }

--- a/app/src/main/res/layout/activity_principal.xml
+++ b/app/src/main/res/layout/activity_principal.xml
@@ -10,6 +10,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:layout="@layout/fragment_menu" />
+    <ProgressBar
+        android:id="@+id/loadingFragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:visibility="gone"
+        tools:visibility="visible" />
     <FrameLayout
             android:id="@+id/frag_container_principal"
             android:layout_width="match_parent"


### PR DESCRIPTION
Se arregla parte de la navegacion para permitir que la app se cierre al ir hacia atras desde la home.
Agregar una progress bar en la activity principal para que se pueda mostrar si una transaccion entre fragments puede tardar (ej. abrir resumen de orden desde la notificacion)