### PR TITLE
Mejoras navegacion pago

### DIFF
--- a/app/src/main/java/com/easypick/easypick/Interfaz/OnBackPressedInterface.kt
+++ b/app/src/main/java/com/easypick/easypick/Interfaz/OnBackPressedInterface.kt
@@ -1,0 +1,5 @@
+package com.easypick.easypick.Interfaz
+
+interface OnBackPressedInterface {
+    fun onBackPressed(): Boolean
+}

--- a/app/src/main/java/com/easypick/easypick/Interfaz/OnBackPressedInterface.kt
+++ b/app/src/main/java/com/easypick/easypick/Interfaz/OnBackPressedInterface.kt
@@ -1,5 +1,5 @@
 package com.easypick.easypick.Interfaz
 
 interface OnBackPressedInterface {
-    fun onBackPressed(): Boolean
+    fun popToTransactionName(): String
 }

--- a/app/src/main/java/com/easypick/easypick/Principal.kt
+++ b/app/src/main/java/com/easypick/easypick/Principal.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.easypick.easypick.API.DatabaseAPI
 import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.firebase.FirebaseToken
@@ -92,10 +93,20 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
             finish()
         }
         else{
-            super.onBackPressed()
+            val currentFragment: Fragment = this.supportFragmentManager.fragments.last()
+            val popTransactionName: String? = (currentFragment as? OnBackPressedInterface)?.
+                popToTransactionName()
+            if (popTransactionName != "" && popTransactionName != null){
+                val result:Boolean = supportFragmentManager.popBackStackImmediate(
+                    popTransactionName, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                if (!result){
+                    super.onBackPressed()
+                }
+            }
+            else{
+                super.onBackPressed()
+            }
         }
-
     }
-
 }
 

--- a/app/src/main/java/com/easypick/easypick/Principal.kt
+++ b/app/src/main/java/com/easypick/easypick/Principal.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.easypick.easypick.API.DatabaseAPI
+import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.firebase.FirebaseToken
 import com.easypick.easypick.fragments.ForceAuthFragment
 import com.easypick.easypick.fragments.FragmentHome
@@ -35,7 +36,7 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
         }
         setContentView(R.layout.activity_principal)
         if (savedInstanceState == null) {
-            showFragment(FragmentHome())
+            showFragment(FragmentHome(), "")
         }
     }
 
@@ -46,10 +47,17 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
         }
     }
 
-    override fun showFragment(fragment: Fragment) {
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.frag_container_principal, fragment).addToBackStack(null)
-            .commit()
+    override fun showFragment(fragment: Fragment, name: String) {
+        if (name == ""){
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.frag_container_principal, fragment).addToBackStack(null)
+                .commit()
+        }
+        else{
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.frag_container_principal, fragment).addToBackStack(name)
+                .commit()
+        }
     }
 
     override fun onStart() {
@@ -73,7 +81,7 @@ class Principal :  BaseActivity(), FragmentHome.OnFragmentInteractionListener,
                         loadingFragment.visibility = View.GONE
                         frag_container_principal.visibility = View.VISIBLE
                     }
-                    order?.let { ResumenOrdenFragment.newInstance(it) }?.let { showFragment(it) }
+                    order?.let { ResumenOrdenFragment.newInstance(it) }?.let { showFragment(it, "") }
                 }
             }
         }

--- a/app/src/main/java/com/easypick/easypick/fragments/ForceAuthFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/ForceAuthFragment.kt
@@ -7,8 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.R
 import com.easypick.easypick.firebase.FirebaseToken
 import com.easypick.easypick.model.Order
@@ -19,7 +17,7 @@ import com.facebook.login.LoginResult
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.android.synthetic.main.fragment_force_auth.*
 
-class ForceAuthFragment: BaseAuthFragment(), OnBackPressedInterface {
+class ForceAuthFragment: BaseAuthFragment() {
     private var listener: FragmentHome.OnFragmentInteractionListener? = null
     private var order: Order? = null
 
@@ -71,7 +69,7 @@ class ForceAuthFragment: BaseAuthFragment(), OnBackPressedInterface {
                     order!!.payer = user?.email?.let {
                         user.displayName?.let { it1 -> User(it, it1, user.uid) } }
                 }
-                listener?.showFragment(PagoFragment.newInstance(order!!), "pagoTransaction")
+                listener?.showFragment(PagoFragment.newInstance(order!!), "")
             }
             else {
                 listener?.showFragment(FragmentOrden(), "")
@@ -119,11 +117,5 @@ class ForceAuthFragment: BaseAuthFragment(), OnBackPressedInterface {
             }
 
         private const val TAG = "SocialAuth"
-    }
-
-    override fun onBackPressed(): Boolean {
-        activity?.supportFragmentManager?.popBackStack(null,
-            FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        return true
     }
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/ForceAuthFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/ForceAuthFragment.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.R
 import com.easypick.easypick.firebase.FirebaseToken
 import com.easypick.easypick.model.Order
@@ -17,7 +19,7 @@ import com.facebook.login.LoginResult
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.android.synthetic.main.fragment_force_auth.*
 
-class ForceAuthFragment: BaseAuthFragment() {
+class ForceAuthFragment: BaseAuthFragment(), OnBackPressedInterface {
     private var listener: FragmentHome.OnFragmentInteractionListener? = null
     private var order: Order? = null
 
@@ -69,10 +71,10 @@ class ForceAuthFragment: BaseAuthFragment() {
                     order!!.payer = user?.email?.let {
                         user.displayName?.let { it1 -> User(it, it1, user.uid) } }
                 }
-                listener?.showFragment(PagoFragment.newInstance(order!!))
+                listener?.showFragment(PagoFragment.newInstance(order!!), "pagoTransaction")
             }
             else {
-                listener?.showFragment(FragmentOrden())
+                listener?.showFragment(FragmentOrden(), "")
             }
         }
     }
@@ -98,7 +100,7 @@ class ForceAuthFragment: BaseAuthFragment() {
      * activity.
      */
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
     companion object {
@@ -117,5 +119,11 @@ class ForceAuthFragment: BaseAuthFragment() {
             }
 
         private const val TAG = "SocialAuth"
+    }
+
+    override fun onBackPressed(): Boolean {
+        activity?.supportFragmentManager?.popBackStack(null,
+            FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        return true
     }
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentHome.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentHome.kt
@@ -60,7 +60,7 @@ class FragmentHome : Fragment(){
 
                         var storeFrangment = FragmentLocal();
                         storeFrangment.store = locales.get(index);
-                        listener?.showFragment(storeFrangment, "")
+                        listener?.showFragment(storeFrangment, "verLocal")
                     }
                 })
             }

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentHome.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentHome.kt
@@ -60,7 +60,7 @@ class FragmentHome : Fragment(){
 
                         var storeFrangment = FragmentLocal();
                         storeFrangment.store = locales.get(index);
-                        listener?.showFragment(storeFrangment)
+                        listener?.showFragment(storeFrangment, "")
                     }
                 })
             }
@@ -114,7 +114,7 @@ class FragmentHome : Fragment(){
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
 

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentLocal.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentLocal.kt
@@ -89,7 +89,7 @@ class FragmentLocal() : Fragment() {
                             override fun onCLick(vista: View, index: Int) {
                                 flag = true
                                 viewModel.categoria = categories?.get(index).name
-                                listener?.showFragment(FragmentProducto())
+                                listener?.showFragment(FragmentProducto(), "")
                             }
                         })
                     }
@@ -132,7 +132,7 @@ class FragmentLocal() : Fragment() {
         if (!flag) {
             viewModel.precioTotal = 0.0
             viewModel.productosSeleccionados.clear()
-            listener?.showFragment(FragmentHome())
+            listener?.showFragment(FragmentHome(), "")
         }
     }
 
@@ -142,7 +142,7 @@ class FragmentLocal() : Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
 

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentMenu.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentMenu.kt
@@ -48,11 +48,11 @@ class FragmentMenu : Fragment() {
         tabs.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab?) {
                 when(tab?.position!!) {
-                    0 -> { listener?.showFragment(FragmentHome()) }
-                    1 -> { listener?.showFragment(FragmentLocal()) }
-                    3 -> { listener?.showFragment(ForceAuthFragment()) }
-                    4 -> { listener?.showFragment(ProfileFragment())}
-                    5 -> { listener?.showFragment(OrderHistoryFragment())}
+                    0 -> { listener?.showFragment(FragmentHome(), "") }
+                    1 -> { listener?.showFragment(FragmentLocal(), "")}
+                    3 -> { listener?.showFragment(ForceAuthFragment(), "") }
+                    4 -> { listener?.showFragment(ProfileFragment(), "")}
+                    5 -> { listener?.showFragment(OrderHistoryFragment(), "")}
                 }
             }
 

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentOrden.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentOrden.kt
@@ -61,7 +61,7 @@ class FragmentOrden : Fragment() {
                         Toast.makeText(activity, "Se ha eliminado ${productosSeleccionados.get(index).descripcion} de la orden", Toast.LENGTH_SHORT).show()
                         viewModel.productosSeleccionados.remove(i)
                     }
-                    listener?.showFragment(FragmentOrdenEliminacion())
+                    listener?.showFragment(FragmentOrdenEliminacion(), "")
                 }
             })
 
@@ -95,7 +95,7 @@ class FragmentOrden : Fragment() {
         val user = firebaseUser?.email?.let {
             firebaseUser.displayName?.let { it1 -> User(it, it1, firebaseUser.uid) } }
         val order = Order(payer=user, items=items, costo=viewModel.precioTotal)
-        listener?.showFragment(ForceAuthFragment.newInstance(order))
+        listener?.showFragment(ForceAuthFragment.newInstance(order), "voyAOrden")
     }
 
     companion object {
@@ -104,7 +104,7 @@ class FragmentOrden : Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentOrden.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentOrden.kt
@@ -95,7 +95,9 @@ class FragmentOrden : Fragment() {
         val user = firebaseUser?.email?.let {
             firebaseUser.displayName?.let { it1 -> User(it, it1, firebaseUser.uid) } }
         val order = Order(payer=user, items=items, costo=viewModel.precioTotal)
-        listener?.showFragment(ForceAuthFragment.newInstance(order), "voyAOrden")
+        viewModel.precioTotal = 0.0
+        viewModel.productosSeleccionados.clear()
+        listener?.showFragment(ForceAuthFragment.newInstance(order), "intentoDePago")
     }
 
     companion object {

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentOrdenEliminacion.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentOrdenEliminacion.kt
@@ -124,7 +124,9 @@ class FragmentOrdenEliminacion : Fragment() {
         val user = firebaseUser?.email?.let {
             firebaseUser.displayName?.let { it1 -> User(it, it1, firebaseUser.uid) } }
         val order = Order(payer=user, items=items, costo=viewModel.precioTotal)
-        listener?.showFragment(ForceAuthFragment.newInstance(order), "voyAOrden")
+        viewModel.precioTotal = 0.0
+        viewModel.productosSeleccionados.clear()
+        listener?.showFragment(ForceAuthFragment.newInstance(order), "intentoDePago")
     }
 
     companion object {

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentOrdenEliminacion.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentOrdenEliminacion.kt
@@ -78,7 +78,7 @@ class FragmentOrdenEliminacion : Fragment() {
                         Toast.makeText(activity, "Se ha eliminado ${productosSeleccionados.get(index).descripcion} de la orden", Toast.LENGTH_SHORT).show()
                         viewModel.productosSeleccionados.remove(i)
                     }
-                    listener?.showFragment(FragmentOrdenEliminacion())
+                    listener?.showFragment(FragmentOrdenEliminacion(), "")
                     if(productosSeleccionados.size == 0){
                         Toast.makeText(activity, "PEDIDO VACIO", Toast.LENGTH_LONG).show()
                         //bandera = false
@@ -97,7 +97,7 @@ class FragmentOrdenEliminacion : Fragment() {
         super.onPause()
         if(!bandera){
             Toast.makeText(activity, "Ejecuta On Pouse", Toast.LENGTH_SHORT)
-            listener?.showFragment(FragmentLocal())
+            listener?.showFragment(FragmentLocal(), "")
         }
     }
 
@@ -124,7 +124,7 @@ class FragmentOrdenEliminacion : Fragment() {
         val user = firebaseUser?.email?.let {
             firebaseUser.displayName?.let { it1 -> User(it, it1, firebaseUser.uid) } }
         val order = Order(payer=user, items=items, costo=viewModel.precioTotal)
-        listener?.showFragment(ForceAuthFragment.newInstance(order))
+        listener?.showFragment(ForceAuthFragment.newInstance(order), "voyAOrden")
     }
 
     companion object {
@@ -148,6 +148,6 @@ class FragmentOrdenEliminacion : Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentProducto.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentProducto.kt
@@ -74,7 +74,7 @@ class FragmentProducto : Fragment() {
             categoria?.text = viewModel.categoria
             catSeleccionada = viewModel.categoria
             btn_carrito.setOnClickListener {
-                listener?.showFragment(fragmentOrden, "entroCarrito")
+                listener?.showFragment(fragmentOrden, "")
             }
             var importeTotal: Double = viewModel.precioTotal
             productos = descargarproductos(catSeleccionada)

--- a/app/src/main/java/com/easypick/easypick/fragments/FragmentProducto.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/FragmentProducto.kt
@@ -74,7 +74,7 @@ class FragmentProducto : Fragment() {
             categoria?.text = viewModel.categoria
             catSeleccionada = viewModel.categoria
             btn_carrito.setOnClickListener {
-                listener?.showFragment(fragmentOrden)
+                listener?.showFragment(fragmentOrden, "entroCarrito")
             }
             var importeTotal: Double = viewModel.precioTotal
             productos = descargarproductos(catSeleccionada)
@@ -149,7 +149,7 @@ class FragmentProducto : Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
     companion object {

--- a/app/src/main/java/com/easypick/easypick/fragments/OrderHistoryFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/OrderHistoryFragment.kt
@@ -34,7 +34,7 @@ class OrderHistoryFragment: Fragment() {
             adapter = OrdersAdapter(orders, object: ClickListener {
                 override fun onCLick(vista: View, index: Int) {
                     val order = orders[index]
-                    listener?.showFragment(ResumenOrdenFragment.newInstance(order))
+                    listener?.showFragment(ResumenOrdenFragment.newInstance(order), "")
                 }
             })
         }.apply {
@@ -42,7 +42,7 @@ class OrderHistoryFragment: Fragment() {
             adapter = OrdersAdapter(orders, object: ClickListener {
                 override fun onCLick(vista: View, index: Int) {
                     val order = orders[index]
-                    listener?.showFragment(ResumenOrdenFragment.newInstance(order))
+                    listener?.showFragment(ResumenOrdenFragment.newInstance(order), "")
                 }
             })
         }
@@ -84,7 +84,7 @@ class OrderHistoryFragment: Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 }
 

--- a/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
@@ -8,7 +8,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.easypick.easypick.API.DatabaseAPI
+import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.R
 import com.easypick.easypick.interfaces.MercadoPagoService
 import com.easypick.easypick.model.Order
@@ -26,7 +28,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.*
 
 
-class PagoFragment : Fragment() {
+class PagoFragment : Fragment(), OnBackPressedInterface {
     private var listener: FragmentHome.OnFragmentInteractionListener? = null
     private lateinit var order: Order
     private val REQUEST_CODE = 1
@@ -80,7 +82,7 @@ class PagoFragment : Fragment() {
                 val payment =
                     data!!.getSerializableExtra(MercadoPagoCheckout.EXTRA_PAYMENT_RESULT) as Payment
                 DatabaseAPI().addOrder(order)
-                listener?.showFragment(ResumenOrdenFragment.newInstance(order))
+                listener?.showFragment(ResumenOrdenFragment.newInstance(order), "")
                 //Done!
             } else if (resultCode == RESULT_CANCELED) {
                 if (data != null && data.extras != null && data.extras!!.containsKey(
@@ -89,7 +91,11 @@ class PagoFragment : Fragment() {
                 ) {
                     val mercadoPagoError =
                         data.getSerializableExtra(MercadoPagoCheckout.EXTRA_ERROR) as MercadoPagoError
+                    activity?.supportFragmentManager?.popBackStack("entroCarrito",
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 } else { //Resolve canceled checkout
+                    activity?.supportFragmentManager?.popBackStack("entroCarrito",
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 }
             }
         }
@@ -110,7 +116,7 @@ class PagoFragment : Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
     companion object {
@@ -122,5 +128,11 @@ class PagoFragment : Fragment() {
                 }
             }
         private const val TAG = "PagoFragment"
+    }
+
+    override fun onBackPressed(): Boolean {
+        activity?.supportFragmentManager?.popBackStack(null,
+            FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        return true
     }
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import com.easypick.easypick.API.DatabaseAPI
 import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.R
@@ -86,13 +85,9 @@ class PagoFragment : Fragment(), OnBackPressedInterface {
                     val mercadoPagoError =
                         data.getSerializableExtra(MercadoPagoCheckout.EXTRA_ERROR) as MercadoPagoError
                     activity?.onBackPressed()
-//                    activity?.supportFragmentManager?.popBackStack("intentoDePago",
-//                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 } else {
                     // El usuario fue para atras / cancelo el pago
                     activity?.onBackPressed()
-//                    activity?.supportFragmentManager?.popBackStack("intentoDePago",
-//                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 }
             }
         }

--- a/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/PagoFragment.kt
@@ -16,7 +16,6 @@ import com.easypick.easypick.interfaces.MercadoPagoService
 import com.easypick.easypick.model.Order
 import com.mercadopago.android.px.core.MercadoPagoCheckout
 import com.mercadopago.android.px.core.MercadoPagoCheckout.Builder
-import com.mercadopago.android.px.model.Payment
 import com.mercadopago.android.px.model.exceptions.MercadoPagoError
 import okhttp3.ResponseBody
 import org.json.JSONObject
@@ -79,23 +78,21 @@ class PagoFragment : Fragment(), OnBackPressedInterface {
     ) {
         if (requestCode == REQUEST_CODE) {
             if (resultCode == MercadoPagoCheckout.PAYMENT_RESULT_CODE) {
-                val payment =
-                    data!!.getSerializableExtra(MercadoPagoCheckout.EXTRA_PAYMENT_RESULT) as Payment
                 DatabaseAPI().addOrder(order)
-                listener?.showFragment(ResumenOrdenFragment.newInstance(order), "")
-                //Done!
+                listener?.showFragment(ResumenOrdenFragment.newInstance(order, true), "")
             } else if (resultCode == RESULT_CANCELED) {
                 if (data != null && data.extras != null && data.extras!!.containsKey(
-                        MercadoPagoCheckout.EXTRA_ERROR
-                    )
-                ) {
+                        MercadoPagoCheckout.EXTRA_ERROR)) {
                     val mercadoPagoError =
                         data.getSerializableExtra(MercadoPagoCheckout.EXTRA_ERROR) as MercadoPagoError
-                    activity?.supportFragmentManager?.popBackStack("entroCarrito",
-                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
-                } else { //Resolve canceled checkout
-                    activity?.supportFragmentManager?.popBackStack("entroCarrito",
-                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    activity?.onBackPressed()
+//                    activity?.supportFragmentManager?.popBackStack("intentoDePago",
+//                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                } else {
+                    // El usuario fue para atras / cancelo el pago
+                    activity?.onBackPressed()
+//                    activity?.supportFragmentManager?.popBackStack("intentoDePago",
+//                        FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 }
             }
         }
@@ -130,9 +127,7 @@ class PagoFragment : Fragment(), OnBackPressedInterface {
         private const val TAG = "PagoFragment"
     }
 
-    override fun onBackPressed(): Boolean {
-        activity?.supportFragmentManager?.popBackStack(null,
-            FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        return true
+    override fun popToTransactionName(): String {
+        return "intentoDePago"
     }
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/ProfileFragment.kt
@@ -80,7 +80,7 @@ class ProfileFragment: BaseAuthFragment() {
      * activity.
      */
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
     companion object {

--- a/app/src/main/java/com/easypick/easypick/fragments/ResumenOrdenFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/ResumenOrdenFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.easypick.easypick.Interfaz.OnBackPressedInterface
 import com.easypick.easypick.R
 import com.easypick.easypick.adapters.EstadoOrdenAdapter
 import com.easypick.easypick.model.Order
@@ -18,17 +19,19 @@ import java.text.DateFormat
 import java.util.*
 import kotlin.collections.ArrayList
 
-class ResumenOrdenFragment: Fragment() {
+class ResumenOrdenFragment: Fragment(), OnBackPressedInterface {
     private lateinit var order: Order
     private var listener: FragmentHome.OnFragmentInteractionListener? = null
     private lateinit var mAdapter: EstadoOrdenAdapter
     private var mDataList = ArrayList<OrderEvent>()
     private lateinit var mLayoutManager: LinearLayoutManager
+    var comesFromPayment: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let {
             order = it.getParcelable("orden")!!
+            comesFromPayment = it.getBoolean("comesFromPayment")
         }
     }
 
@@ -86,13 +89,22 @@ class ResumenOrdenFragment: Fragment() {
 
     companion object {
         @JvmStatic
-        fun newInstance(orden: Order) =
+        fun newInstance(orden: Order, comesFromPayment: Boolean=false) =
             ResumenOrdenFragment().apply {
                 arguments = Bundle().apply {
                     putParcelable("orden", orden)
+                    putBoolean("comesFromPayment", comesFromPayment)
                 }
             }
         private const val TAG = "ResumenOrdenFragment"
+    }
+
+    override fun popToTransactionName(): String {
+        return if (comesFromPayment){
+            "verLocal"
+        } else{
+            ""
+        }
     }
 
 }

--- a/app/src/main/java/com/easypick/easypick/fragments/ResumenOrdenFragment.kt
+++ b/app/src/main/java/com/easypick/easypick/fragments/ResumenOrdenFragment.kt
@@ -81,7 +81,7 @@ class ResumenOrdenFragment: Fragment() {
     }
 
     interface OnFragmentInteractionListener {
-        fun showFragment(fragment: Fragment)
+        fun showFragment(fragment: Fragment, name: String)
     }
 
     companion object {


### PR DESCRIPTION
Closes #20

- Una vez hecho el pago, si vas para atras desde la pantalla del resumen de la orden, volves a la home y no al pago de fragment de nuevo

- Si en la mitad del pago queres salir, volves al carrito. Que quedo vaciado, vale la pena mantenerlo?

Todo esto se usa nombrando las transacciones para despues poder hacer popBackStack para hacer rollback hasta esa transaccion 